### PR TITLE
feat: dockerize app with dev/prod compose setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,9 @@ __pycache__
 .pytest_cache
 .ruff_cache
 *.db
+.env
+.env.*
+tests/
+.github/
+docs/
+*.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,14 +3,21 @@ FROM python:3.12-slim AS base
 WORKDIR /app
 
 COPY pyproject.toml .
-COPY src/ src/
-
 RUN pip install --no-cache-dir .
 
+COPY src/ src/
+
+RUN adduser --disabled-password --no-create-home appuser
+USER appuser
+
 FROM base AS prod
+USER root
 RUN pip install --no-cache-dir gunicorn
+USER appuser
 CMD ["gunicorn", "kingpi.app:app", "-w", "4", "-k", "uvicorn.workers.UvicornWorker", "-b", "0.0.0.0:8000"]
 
 FROM base AS dev
+USER root
 RUN pip install --no-cache-dir ".[dev]"
+USER appuser
 CMD ["uvicorn", "kingpi.app:app", "--host", "0.0.0.0", "--port", "8000", "--reload", "--reload-dir", "src"]

--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,10 @@ prod:
 	docker compose -f docker-compose.yml -f docker-compose.prod.yml up --build -d
 
 down:
-	docker compose down
+	docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.prod.yml down
 
 logs:
-	docker compose logs -f
+	docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.prod.yml logs -f
 
 test:
 	docker compose -f docker-compose.yml -f docker-compose.dev.yml run --rm app pytest

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,4 +1,7 @@
 services:
+  redis:
+    ports:
+      - "127.0.0.1:6379:6379"
   app:
     build:
       context: .

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -5,8 +5,14 @@ services:
       target: prod
     ports:
       - "8000:8000"
+    restart: unless-stopped
     environment:
       - KINGPI_REDIS_URL=redis://redis:6379/0
     depends_on:
       redis:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,7 @@
 services:
   redis:
     image: redis:7-alpine
-    ports:
-      - "6379:6379"
+    restart: unless-stopped
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 5s


### PR DESCRIPTION
## Summary
- Multi-stage Dockerfile with `dev` (uvicorn --reload) and `prod` (gunicorn + uvicorn workers) targets
- Docker Compose base with Redis healthcheck, plus dev and prod override files
- Makefile shortcuts: `make dev`, `make prod`, `make down`, `make logs`, `make test`

## Test plan
- [x] `make dev` builds and starts app + Redis
- [x] Health endpoint responds at localhost:8000/health
- [x] Redis caching works (key created after first request, second request 7x faster)
- [x] TTL set correctly (300s)
- [ ] `make prod` builds with gunicorn
- [ ] `make test` runs pytest in container