### PR TITLE
fix: handle PyPIUpstreamError and TimeoutException in routes

### DIFF
--- a/src/kingpi/api/events.py
+++ b/src/kingpi/api/events.py
@@ -19,13 +19,14 @@ Key FastAPI concepts used here:
   instance into route handlers. This avoids global state and makes routes easy
   to test by overriding dependencies (see conftest.py).
 """
+import httpx
 from fastapi import APIRouter, Depends, HTTPException
 
 from kingpi.dependencies import get_event_store, get_pypi_cache_client
 from kingpi.schemas.event import EventIn
 from kingpi.services.event_store import EventStore
 from kingpi.services.pypi_cache_client import PackageInfoFetcher
-from kingpi.services.pypi_client import PackageNotFoundError
+from kingpi.services.pypi_client import PackageNotFoundError, PyPIUpstreamError
 
 router = APIRouter()
 
@@ -40,5 +41,11 @@ async def post_event(
         await pypi.fetch_package_info(event.package)
     except PackageNotFoundError:
         raise HTTPException(status_code=404, detail=f"Package '{event.package}' not found on PyPI")
+    except PyPIUpstreamError as exc:
+        raise HTTPException(status_code=502, detail=str(exc))
+    except httpx.TimeoutException:
+        raise HTTPException(status_code=504, detail="PyPI request timed out")
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
     await store.record_event(event.package, event.type, event.timestamp)
     return {"status": "accepted"}

--- a/src/kingpi/api/packages.py
+++ b/src/kingpi/api/packages.py
@@ -6,6 +6,7 @@ from PyPI and querying recorded event statistics. Routes are kept thin —
 business logic lives in the service layer (package_service.py).
 """
 
+import httpx
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import PlainTextResponse
 
@@ -15,7 +16,7 @@ from kingpi.schemas.package import PackageSummaryResponse
 from kingpi.services.event_store import EventStore
 from kingpi.services.package_service import get_package_summary
 from kingpi.services.pypi_cache_client import PackageInfoFetcher
-from kingpi.services.pypi_client import PackageNotFoundError
+from kingpi.services.pypi_client import PackageNotFoundError, PyPIUpstreamError
 
 router = APIRouter()
 
@@ -30,6 +31,12 @@ async def get_package(
         return await get_package_summary(name, pypi, store)
     except PackageNotFoundError:
         raise HTTPException(status_code=404, detail=f"Package '{name}' not found")
+    except PyPIUpstreamError as exc:
+        raise HTTPException(status_code=502, detail=str(exc))
+    except httpx.TimeoutException:
+        raise HTTPException(status_code=504, detail="PyPI request timed out")
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
 
 
 @router.get("/package/{name}/event/{event_type}/total", response_class=PlainTextResponse)

--- a/src/kingpi/services/pypi_cache_client.py
+++ b/src/kingpi/services/pypi_cache_client.py
@@ -12,10 +12,13 @@ implement, allowing the service layer to depend on the abstraction.
 from __future__ import annotations
 
 import json
+import logging
 import re
 from typing import Protocol
 
 from kingpi.services.cache import Cache
+
+logger = logging.getLogger(__name__)
 
 
 class PackageInfoFetcher(Protocol):
@@ -49,7 +52,11 @@ class PyPICacheClient:
 
         cached = await self._cache.get(cache_key)
         if cached is not None:
-            return json.loads(cached)
+            try:
+                return json.loads(cached)
+            except json.JSONDecodeError:
+                logger.warning("Corrupt cache entry for key %s, treating as miss", cache_key)
+                await self._cache.delete(cache_key)
 
         data = await self._client.fetch_package_info(package)
         await self._cache.set(cache_key, json.dumps(data), self._ttl_seconds)

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -16,6 +16,10 @@ The event store is mocked so tests are fast and isolated from storage logic.
 """
 from datetime import datetime, timedelta, timezone
 
+import httpx
+
+from kingpi.services.pypi_client import PyPIUpstreamError
+
 
 # A valid payload used as a baseline — individual tests copy and mutate it
 # using dict unpacking: `{**VALID_PAYLOAD, "type": "download"}` creates a
@@ -82,3 +86,22 @@ async def test_post_event_future_timestamp(client):
     payload = {**VALID_PAYLOAD, "timestamp": future}
     response = await client.post("/api/v1/event", json=payload)
     assert response.status_code == 201
+
+
+async def test_post_event_pypi_upstream_error(client, mock_pypi_client):
+    mock_pypi_client.fetch_package_info.side_effect = PyPIUpstreamError("requests", 503)
+    response = await client.post("/api/v1/event", json=VALID_PAYLOAD)
+    assert response.status_code == 502
+
+
+async def test_post_event_pypi_timeout(client, mock_pypi_client):
+    mock_pypi_client.fetch_package_info.side_effect = httpx.TimeoutException("connection timed out")
+    response = await client.post("/api/v1/event", json=VALID_PAYLOAD)
+    assert response.status_code == 504
+
+
+async def test_post_event_invalid_package_name(client, mock_pypi_client):
+    mock_pypi_client.fetch_package_info.side_effect = ValueError("Invalid package name: '../evil'")
+    payload = {**VALID_PAYLOAD, "package": "../evil"}
+    response = await client.post("/api/v1/event", json=payload)
+    assert response.status_code == 400

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -15,11 +15,13 @@ The global `client` fixture only overrides `get_event_store`. These tests also
 need to mock `get_pypi_cache_client` so we don't make real HTTP calls to PyPI.
 Defining `test_client` locally keeps this setup self-contained.
 """
+import httpx
 import pytest
 from httpx import ASGITransport, AsyncClient
 
 from kingpi.app import create_app
 from kingpi.dependencies import get_event_store, get_pypi_cache_client
+from kingpi.services.pypi_client import PyPIUpstreamError
 
 
 # Realistic but minimal PyPI API response — used by the mock_pypi_client fixture
@@ -103,3 +105,21 @@ async def test_get_package_event_total_no_events(test_client):
     response = await test_client.get("/api/v1/package/new-package/event/install/total")
     assert response.status_code == 200
     assert response.text == "0"
+
+
+async def test_get_package_pypi_upstream_error(test_client, mock_pypi_client):
+    mock_pypi_client.fetch_package_info.side_effect = PyPIUpstreamError("requests", 503)
+    response = await test_client.get("/api/v1/package/requests")
+    assert response.status_code == 502
+
+
+async def test_get_package_pypi_timeout(test_client, mock_pypi_client):
+    mock_pypi_client.fetch_package_info.side_effect = httpx.TimeoutException("connection timed out")
+    response = await test_client.get("/api/v1/package/requests")
+    assert response.status_code == 504
+
+
+async def test_get_package_invalid_package_name(test_client, mock_pypi_client):
+    mock_pypi_client.fetch_package_info.side_effect = ValueError("Invalid package name: '_invalid_'")
+    response = await test_client.get("/api/v1/package/_invalid_")
+    assert response.status_code == 400

--- a/tests/test_pypi_cache_client.py
+++ b/tests/test_pypi_cache_client.py
@@ -123,3 +123,15 @@ async def test_upstream_error_not_cached_no_set(cached_client, mock_pypi, cache)
         await cached_client.fetch_package_info("pkg")
 
     cache.set.assert_not_awaited()
+
+
+async def test_corrupt_cache_treated_as_miss(mock_pypi, cache):
+    """Corrupt (non-JSON) cache data should be treated as a miss, not raise."""
+    cache.get.return_value = "not-valid-json{{{{"
+    cached_client = PyPICacheClient(client=mock_pypi, cache=cache, ttl_seconds=300)
+
+    result = await cached_client.fetch_package_info("requests")
+
+    assert result == SAMPLE_DATA
+    cache.delete.assert_awaited_once_with("pypi:package:requests")
+    mock_pypi.fetch_package_info.assert_awaited_once_with("requests")


### PR DESCRIPTION
## Summary
- Catch `PyPIUpstreamError` → 502 Bad Gateway in both `api/events.py` and `api/packages.py`
- Catch `httpx.TimeoutException` → 504 Gateway Timeout in both route files
- Catch `ValueError` from package name validation → 400 Bad Request in both route files
- Prevents raw 500 errors and stack trace leaks when PyPI is unreachable or returns errors

## Test plan
- [x] Added 3 new tests in `test_events.py` (upstream error, timeout, invalid name)
- [x] Added 3 new tests in `test_packages.py` (upstream error, timeout, invalid name)
- [x] All 78 tests pass, no regressions
- [x] Tests followed TDD — written before implementation, confirmed RED then GREEN

Closes #27